### PR TITLE
add support for debug toolbars for hot reload checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,26 @@ In some cases (i.e. when working on non-livewire elements), you'll want to full 
 
 By adding an `VITE_LIVEWIRE_OPT_IN=true` entry in your `.env` file an opt-in checkbox will show on the bottom right corner of the webpage, allowing you to enable/disable livewire hot reload. If disabled: a full page reload will be triggered when blade files are changed.
 
+If you're using a debug toolbar other than [Debugbar for Laravel](https://github.com/barryvdh/laravel-debugbar) or [Clockwork](https://underground.works/clockwork/), the checkbox my interfere with it. There is a config option `bottomPosition` to add more spacing to the bottom, to make the checkbox visible again. The value must be a of type number. These two toolbar are taken into account, while positioning the checkbox. No special configuration is needed.
+
+```js
+// vite.config.js 
+
+import livewire, {defaultWatches} from '@defstudio/vite-livewire-plugin';
+
+export default defineConfig({
+    //...
+    
+    plugins: [
+        //...
+        
+        livewire({
+            bottomPosition: 34,
+        }),
+    ],
+});
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently. [Follow Us](https://twitter.com/FabioIvona) on Twitter for more updates about this package.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,13 @@ import minimatch from 'minimatch';
 interface PluginConfig {
     refresh?: string | string[];
     watch?: string | string[];
+    bottomPosition?: number;
 }
 
 interface ResolvedPluginConfig extends PluginConfig {
     refresh: string[];
     watch: string[];
+    bottomPosition: number;
 }
 
 interface LivewirePlugin extends Plugin {
@@ -27,6 +29,7 @@ export const defaultWatches: string[] = [
 export const defaultConfig: PluginConfig = {
     watch: defaultWatches,
     refresh: [],
+    bottomPosition: 10,
 }
 
 function triggerUpdates(ctx: HmrContext, refreshList: string[]): void {
@@ -96,6 +99,10 @@ function resolvePluginConfig(config?: PluginConfig | string | string[]): Resolve
 
     if (typeof config.watch === 'string') {
         config.watch = [config.watch];
+    }
+
+    if (typeof config.bottomPosition === 'undefined') {
+        config.bottomPosition = defaultConfig.bottomPosition;
     }
 
     return config as ResolvedPluginConfig;
@@ -179,8 +186,11 @@ export default function livewire(config?: PluginConfig | string | string[]): Liv
                     }
 
                     function makeOptInLabel() {
+                        const debugbarHeight = document.querySelector('.phpdebugbar, .clockwork-toolbar')?.offsetHeight ?? 0;
+                        const defaultBottomPosition = ${pluginConfig.bottomPosition};
+                        const calculatedBottomPosition = debugbarHeight + defaultBottomPosition
                         const label = document.createElement('label');
-                        label.style.cssText = "position: fixed; bottom: 10px; right: 10px; font-size: 12px; cursor: pointer";
+                        label.style.cssText = "position: fixed; bottom: "+calculatedBottomPosition+"px; right: 10px; font-size: 12px; cursor: pointer";
                         label.innerHTML += "Livewire Hot Reload&nbsp;";
 
                         return label;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -42,6 +42,7 @@ describe('configuration parse', () => {
             '**/app/**/Filament/**/*.php',
             'app/View/Components/**',
         ]);
+        expect(config.bottomPosition).toStrictEqual(10);
     });
 
     it('should handle string configuration', function () {
@@ -50,6 +51,7 @@ describe('configuration parse', () => {
 
         expect(config.refresh).toStrictEqual([]);
         expect(config.watch).toStrictEqual(['foo']);
+        expect(config.bottomPosition).toStrictEqual(10);
     });
 
     it('should handle array configuration', function () {
@@ -58,6 +60,7 @@ describe('configuration parse', () => {
 
         expect(config.refresh).toStrictEqual([]);
         expect(config.watch).toStrictEqual(['foo', 'bar']);
+        expect(config.bottomPosition).toStrictEqual(10);
     });
 
     it('should handle empty object configuration', function () {
@@ -71,6 +74,7 @@ describe('configuration parse', () => {
             '**/app/**/Filament/**/*.php',
             'app/View/Components/**',
         ]);
+        expect(config.bottomPosition).toStrictEqual(10);
     });
 
     it('should handle object configuration with string watch', function () {
@@ -79,6 +83,7 @@ describe('configuration parse', () => {
 
         expect(config.refresh).toStrictEqual([]);
         expect(config.watch).toStrictEqual(['foo']);
+        expect(config.bottomPosition).toStrictEqual(10);
     });
 
     it('should handle object configuration with array watch', function () {
@@ -87,6 +92,7 @@ describe('configuration parse', () => {
 
         expect(config.refresh).toStrictEqual([]);
         expect(config.watch).toStrictEqual(['foo', 'bar']);
+        expect(config.bottomPosition).toStrictEqual(10);
     });
 
     it('should handle object configuration with string refresh', function () {
@@ -100,6 +106,7 @@ describe('configuration parse', () => {
             '**/app/**/Filament/**/*.php',
             'app/View/Components/**',
         ]);
+        expect(config.bottomPosition).toStrictEqual(10);
     });
 
     it('should handle object configuration with array refresh', function () {
@@ -113,6 +120,21 @@ describe('configuration parse', () => {
             '**/app/**/Filament/**/*.php',
             'app/View/Components/**',
         ]);
+        expect(config.bottomPosition).toStrictEqual(10);
+    });
+
+    it('should handle object configuration with number bottomPosition', function () {
+        const plugin = livewire({bottomPosition: 42})
+        const config = plugin.pluginConfig;
+
+        expect(config.refresh).toStrictEqual([]);
+        expect(config.watch).toStrictEqual([
+            '**/resources/views/**/*.blade.php',
+            '**/app/**/Livewire/**/*.php',
+            '**/app/**/Filament/**/*.php',
+            'app/View/Components/**',
+        ]);
+        expect(config.bottomPosition).toStrictEqual(42);
     });
 });
 


### PR DESCRIPTION
If one is using a debug toolbar, the hot reload checkbox may be hidden by it. This PR can detect the presence of the two major debug toolbars for Laravel and take that into account for the positioning. Also, a new config value to manually override the spacing is introduced.