### PR TITLE
Adds Vite 5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,25 +38,25 @@
         "test": "vitest run"
     },
     "devDependencies": {
-        "@types/minimatch": "^5.1.0",
-        "@types/node": "^20.1.0",
-        "@types/picomatch": "^2.3.0",
-        "@typescript-eslint/eslint-plugin": "^6.0.0",
-        "@typescript-eslint/parser": "^6.1.0",
-        "esbuild": "0.19.12",
-        "eslint": "^8.14.0",
-        "typescript": "^5.0.3",
-        "vite": "^4.0.1",
-        "vitest": "^1.0.2"
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "^20.11.16",
+        "@types/picomatch": "^2.3.3",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "esbuild": "0.20.0",
+        "eslint": "^8.56.0",
+        "typescript": "^5.3.3",
+        "vite": "^5.0.0",
+        "vitest": "^1.2.2"
     },
     "peerDependencies": {
-        "vite": "^4.0.0"
+        "vite": "^5.0.0"
     },
     "engines": {
-        "node": ">=14"
+        "node": ">=18"
     },
     "dependencies": {
         "minimatch": "^9.0.3",
-        "vite-plugin-full-reload": "^1.0.0"
+        "vite-plugin-full-reload": "^1.1.0"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "target": "ES2020",
         "module": "ES2020",
         "moduleResolution": "node",
+        "skipLibCheck": true,
         "resolveJsonModule": true,
         "strict": true,
         "declaration": true,


### PR DESCRIPTION
Aloha! 🌺 I just did some virtual hula dancing to add Vite 5 support. I've thrown it in there like confetti at a beach party. Take a peek and give it a whirl! Test it out, and fingers crossed, it should be smoother than a surfing penguin. 🐧🏄‍♂️ Let me know how it grooves! 🤙

Had to add skipLibCheck to tsconfig.json because of:
* https://github.com/vitest-dev/vitest/issues/4567
* https://github.com/vitejs/vite/issues/15714

Looks like the type definitions from Vite 5 are doing the Macarena when they should be doing the Cha-Cha. Can you figure out the dance floor drama? Maybe they're just having a wild party and need a sober code enforcer. Any insights on their dance moves? 💃🕺 Let me know if you can help me make sense of this dance-off! 🕵️‍♂️🎉