### PR TITLE
fix: Add full Vite 8 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "license": "MIT",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/index.mjs",
-            "require": "./dist/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/index.cjs"
         }
     },
     "files": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@types/picomatch": "^4.0.1",
         "@typescript-eslint/eslint-plugin": "^8.8.1",
         "@typescript-eslint/parser": "^8.8.1",
-        "esbuild": "0.28.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "eslint": "^10.0.0",
         "globals": "^17.0.0",
         "typescript": "^6.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 // noinspection JSUnusedLocalSymbols
 
-import {HmrContext, Plugin} from "vite";
-import {Update} from "vite/types/hmrPayload";
+import {EnvironmentModuleNode, HotUpdateOptions, Plugin, Update} from "vite";
 
 import {minimatch} from 'minimatch';
 
@@ -34,7 +33,7 @@ export const defaultConfig: PluginConfig = {
     bottomPosition: 10,
 }
 
-function triggerUpdates(ctx: HmrContext, refreshList: string[]): void {
+function triggerUpdates(ctx: HotUpdateOptions, refreshList: string[]): void {
     const updates = [];
     for (const path of refreshList) {
         let type;
@@ -55,7 +54,7 @@ function triggerUpdates(ctx: HmrContext, refreshList: string[]): void {
     }
 
     if (updates.length > 0) {
-        ctx.server.ws.send({
+        ctx.server.hot.send({
             type: 'update',
             updates: updates,
         });
@@ -63,8 +62,8 @@ function triggerUpdates(ctx: HmrContext, refreshList: string[]): void {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function refresh(ctx: HmrContext, config: ResolvedPluginConfig): void {
-    ctx.server.ws.send({
+function refresh(ctx: HotUpdateOptions, config: ResolvedPluginConfig): void {
+    ctx.server.hot.send({
         type: 'custom',
         event: 'livewire-update',
         data: {
@@ -123,7 +122,7 @@ export default function livewire(config?: PluginConfig | string | string[]): Liv
     const pluginConfig = resolvePluginConfig(config);
 
     return {
-        name: 'Tailwind Plugin',
+        name: 'Vite Livewire Plugin',
         pluginConfig: pluginConfig,
         resolveId(id) {
             if (id === virtualModuleId || id === typoVirtualModuleId) {
@@ -255,7 +254,10 @@ export default function livewire(config?: PluginConfig | string | string[]): Liv
                 `;
             }
         },
-        handleHotUpdate(ctx) {
+        hotUpdate(ctx) {
+            if (ctx.type !== 'update') {
+                return;
+            }
 
             if (minimatch(ctx.file, '**/storage/framework/views/**/*.php')) {
                 return [];
@@ -269,9 +271,9 @@ export default function livewire(config?: PluginConfig | string | string[]): Liv
                         }
 
                         let includeInRefresh = true;
-                        ctx.modules[0].importers.forEach(importer => {
-                            //@ts-expect-error may be nullish depending on npm used version
-                            includeInRefresh = !importer.file?.endsWith(path) ?? false;
+                        ctx.modules[0].importers.forEach((importer: EnvironmentModuleNode) => {
+                            // may be nullish depending on npm used version
+                            includeInRefresh = !importer.file?.endsWith(path);
                         });
                         return includeInRefresh;
                     })];

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3,25 +3,31 @@
 
 import {afterEach, describe, expect, it, vi} from "vitest";
 import livewire, {defaultWatches} from "../src";
-import {HmrContext, HMRPayload, ViteDevServer} from "vite";
+import {HotUpdateOptions, HotPayload, ViteDevServer, Plugin} from "vite";
 
-function fakeContext(file = ''): HmrContext {
+function fakeContext(file = ''): HotUpdateOptions {
     return {
+        type: 'update',
         file: file,
         modules: [],
         read(): string | Promise<string> {
             return '';
         },
         server: {
-            ws: {
-
-                send: (payload: HMRPayload) => {
+            hot: {
+                send: (payload: HotPayload) => {
                     //.. do nothing
                 }
             }
         } as ViteDevServer,
         timestamp: 0
     };
+}
+
+function callHotUpdate(hook: Plugin['hotUpdate'], ctx: HotUpdateOptions) {
+    if (!hook) return;
+    const fn = typeof hook === 'function' ? hook : hook.handler;
+    return fn.call({} as never, ctx);
 }
 
 function freezeTime(date = new Date(2000, 1, 1, 13)): Date
@@ -146,16 +152,16 @@ describe('hot update handling', () => {
     it("should not trigger hot update if file doesn't match any pattern", function () {
         const plugin = livewire();
 
-        plugin.handleHotUpdate?.(fakeContext());
+        callHotUpdate(plugin.hotUpdate, fakeContext());
     });
 
     it("should trigger hot update if file matches default class pattern", function () {
         const plugin = livewire();
 
         const context = fakeContext('/var/www/app/Html/Livewire/Test.php');
-        const spy = vi.spyOn(context.server.ws, 'send');
+        const spy = vi.spyOn(context.server.hot, 'send');
 
-        plugin.handleHotUpdate?.(context);
+        callHotUpdate(plugin.hotUpdate, context);
 
         expect(spy).toHaveBeenCalledWith({
             type: 'custom',
@@ -170,13 +176,13 @@ describe('hot update handling', () => {
         });
 
         const context = fakeContext('/var/www/app/Html/Livewire/Test.php');
-        const spy = vi.spyOn(context.server.ws, 'send');
+        const spy = vi.spyOn(context.server.hot, 'send');
 
-        plugin.handleHotUpdate?.(context);
+        callHotUpdate(plugin.hotUpdate, context);
         expect(spy).toHaveBeenCalledTimes(0);
 
         context.file = 'var/www/app/modules/invoices/views/livewire/test.blade.php';
-        plugin.handleHotUpdate?.(context);
+        callHotUpdate(plugin.hotUpdate, context);
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -189,9 +195,9 @@ describe('hot update handling', () => {
         });
 
         const context = fakeContext('/var/www/app/Html/Livewire/Test.php');
-        const spy = vi.spyOn(context.server.ws, 'send');
+        const spy = vi.spyOn(context.server.hot, 'send');
 
-        plugin.handleHotUpdate?.(context);
+        callHotUpdate(plugin.hotUpdate, context);
         expect(spy).toHaveBeenCalledWith({
             type: 'custom',
             event: 'livewire-update',
@@ -199,7 +205,7 @@ describe('hot update handling', () => {
         });
 
         context.file = 'var/www/app/modules/invoices/views/livewire/test.blade.php';
-        plugin.handleHotUpdate?.(context);
+        callHotUpdate(plugin.hotUpdate, context);
         expect(spy).toHaveBeenCalledTimes(2);
         expect(spy).toHaveBeenLastCalledWith({
             type: 'custom',
@@ -212,9 +218,9 @@ describe('hot update handling', () => {
         const plugin = livewire();
 
         const context = fakeContext('/var/www/resources/views/test.blade.php');
-        const spy = vi.spyOn(context.server.ws, 'send');
+        const spy = vi.spyOn(context.server.hot, 'send');
 
-        plugin.handleHotUpdate?.(context);
+        callHotUpdate(plugin.hotUpdate, context);
 
         expect(spy).toHaveBeenCalledTimes(1);
     });
@@ -225,9 +231,9 @@ describe('hot update handling', () => {
         });
 
         const context = fakeContext('/var/www/resources/components/test.blade.php');
-        const spy = vi.spyOn(context.server.ws, 'send');
+        const spy = vi.spyOn(context.server.hot, 'send');
 
-        plugin.handleHotUpdate?.(context);
+        callHotUpdate(plugin.hotUpdate, context);
 
         expect(spy).toHaveBeenCalledTimes(0);
     });
@@ -238,11 +244,11 @@ describe('hot update handling', () => {
         });
 
         const context = fakeContext('/var/www/resources/views/test.blade.php');
-        const spy = vi.spyOn(context.server.ws, 'send');
+        const spy = vi.spyOn(context.server.hot, 'send');
 
         const time = freezeTime();
 
-        plugin.handleHotUpdate?.(context);
+        callHotUpdate(plugin.hotUpdate, context);
 
         expect(spy).toHaveBeenCalledTimes(2);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "target": "ES2020",
         "module": "ES2020",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "skipLibCheck": true,
         "resolveJsonModule": true,
         "strict": true,


### PR DESCRIPTION
Here's what I did:

- Fix esbuild peer dependency conflict with Vite 8 (^0.27.0)
- Switch moduleResolution to bundler in tsconfig.json to support Vite 8's package exports
- Replace deprecated server.ws with server.hot (Vite 6+ API)
- Migrate handleHotUpdate hook to hotUpdate (environment-aware Vite 6+ API), adding an explicit type === 'update' guard
- Replace deprecated HMRPayload with HotPayload in tests
- Import Update directly from vite instead of vite/types/hmrPayload
- Fix no-constant-binary-expression lint error (?? false after ! operator)

Tests run locally through on NodeJS 20/22